### PR TITLE
Update Utils.java

### DIFF
--- a/weld-ee-embedded-1.1/src/main/java/org/jboss/arquillian/container/weld/ee/embedded_1_1/Utils.java
+++ b/weld-ee-embedded-1.1/src/main/java/org/jboss/arquillian/container/weld/ee/embedded_1_1/Utils.java
@@ -199,6 +199,7 @@ final class Utils
       }
       className = className.replaceAll("\\.class", "");
       className = className.replaceAll("/", ".");
+      className = className.replaceAll("\\\\", ".");
       return className;
    }
 


### PR DESCRIPTION
when using with shrinkwrap maven resolver, the archive's getContent method returns class format as "\org\test\something". This causes java.lang.NoClassDefFoundError because findClassName method could not replace all slashes in class's full name.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arquillian/arquillian-container-weld/12)

<!-- Reviewable:end -->
