### PR TITLE
Add literals for Initialized and Destroyed.

### DIFF
--- a/impl/src/main/java/org/jboss/arquillian/container/weld/embedded/literals/DestroyedLiteral.java
+++ b/impl/src/main/java/org/jboss/arquillian/container/weld/embedded/literals/DestroyedLiteral.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.weld.embedded.literals;
+
+import java.lang.annotation.Annotation;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Destroyed;
+import javax.enterprise.util.AnnotationLiteral;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@SuppressWarnings("all")
+public class DestroyedLiteral extends AnnotationLiteral<Destroyed> implements Destroyed {
+
+    public static final DestroyedLiteral APPLICATION = new DestroyedLiteral(ApplicationScoped.class);
+
+    private Class<? extends Annotation> value;
+
+    private DestroyedLiteral(Class<? extends Annotation> value) {
+        this.value = value;
+    }
+
+    @Override
+    public Class<? extends Annotation> value() {
+        return value;
+    }
+}

--- a/impl/src/main/java/org/jboss/arquillian/container/weld/embedded/literals/InitializedLiteral.java
+++ b/impl/src/main/java/org/jboss/arquillian/container/weld/embedded/literals/InitializedLiteral.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.container.weld.embedded.literals;
+
+import java.lang.annotation.Annotation;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Initialized;
+import javax.enterprise.util.AnnotationLiteral;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@SuppressWarnings("all")
+public class InitializedLiteral extends AnnotationLiteral<Initialized> implements Initialized {
+
+    public static final InitializedLiteral APPLICATION = new InitializedLiteral(ApplicationScoped.class);
+
+    private Class<? extends Annotation> value;
+
+    private InitializedLiteral(Class<? extends Annotation> value) {
+        this.value = value;
+    }
+
+    @Override
+    public Class<? extends Annotation> value() {
+        return value;
+    }
+}

--- a/impl/src/main/java/org/jboss/arquillian/container/weld/embedded/mock/TestContainer.java
+++ b/impl/src/main/java/org/jboss/arquillian/container/weld/embedded/mock/TestContainer.java
@@ -36,10 +36,12 @@ import org.jboss.weld.bootstrap.spi.Deployment;
 import org.jboss.weld.context.RequestContext;
 import org.jboss.weld.context.bound.BoundSessionContext;
 import org.jboss.weld.context.unbound.UnboundLiteral;
-import org.jboss.weld.literal.DestroyedLiteral;
-import org.jboss.weld.literal.InitializedLiteral;
 import org.jboss.weld.manager.api.WeldManager;
+
 import static java.util.Arrays.asList;
+
+import org.jboss.arquillian.container.weld.embedded.literals.DestroyedLiteral;
+import org.jboss.arquillian.container.weld.embedded.literals.InitializedLiteral;
 
 /**
  * <p>


### PR DESCRIPTION
In order to make this work with Weld 3.x, we need to declare Initialized & Destroyed literals here.
Previously, they were taken from Weld core (those will be deleted).
In CDI 2.0 they are already present in the API, yet we cannot declare dependency on 2.0 here (as we need it to run with older versions as well).