### PR TITLE
fix: travis build settings to use openjdk7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: java
 jdk:
-  - oraclejdk7
-script: "mvn clean install"
-sudo: false
+  - openjdk7
+cache:
+  directories:
+    - $HOME/.m2
+install: true
+script: 
+  - mvn clean install


### PR DESCRIPTION
This fixes `JAVA_HOME` error for JDK 7. Using `oraclejdk7` results in error about `JAVA_HOME` not being defined.

In addition, tweaked the config to cache maven repo for the builds.