### PR TITLE
Fix ContainerCDIProvider not throwing right exception when CDI contai…

### DIFF
--- a/impl/src/main/java/org/jboss/arquillian/container/weld/embedded/provider/ContainerCDIProvider.java
+++ b/impl/src/main/java/org/jboss/arquillian/container/weld/embedded/provider/ContainerCDIProvider.java
@@ -41,12 +41,20 @@ public class ContainerCDIProvider implements CDIProvider {
             // sort the managers by their ID and use the first one as the fallback BeanManager
             // this guarantees that we consistently use the same BM
             List<BeanManagerImpl> managers = new ArrayList<BeanManagerImpl>(getContainer().beanDeploymentArchives().values());
-            Collections.sort(managers, BeanManagers.ID_COMPARATOR);
-            this.fallbackBeanManager = managers.get(0);
+
+            if (!managers.isEmpty()) {
+                Collections.sort(managers, BeanManagers.ID_COMPARATOR);
+                this.fallbackBeanManager = managers.get(0);
+            } else {
+                this.fallbackBeanManager = null;
+            }
         }
 
         @Override
         protected BeanManagerImpl unsatisfiedBeanManager(String callerClassName) {
+            if (fallbackBeanManager == null) {
+                throw new IllegalStateException("Unable to find BeanManager for " + callerClassName);
+            }
             return fallbackBeanManager;
         }
     }


### PR DESCRIPTION
…ner isn't available

#### Short description of what this resolves:
CDIProvider should throw IllegalStateException if no CDI container is available - 
[https://javaee.github.io/javaee-spec/javadocs/javax/enterprise/inject/spi/CDIProvider.html#getCDI--](https://javaee.github.io/javaee-spec/javadocs/javax/enterprise/inject/spi/CDIProvider.html#getCDI--)

#### Changes proposed in this pull request:

- ContainerCDIProvider throws IllegalStateException instead of IndexOutOfBoundsException when CDI context cannot be found
