### PR TITLE
Classes from MR jars now have their META-INF prefix removed during pr…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
-  - openjdk7
+  - openjdk8
+  - openjdk11
 cache:
   directories:
     - $HOME/.m2

--- a/impl/src/main/java/org/jboss/arquillian/container/weld/embedded/Utils.java
+++ b/impl/src/main/java/org/jboss/arquillian/container/weld/embedded/Utils.java
@@ -164,7 +164,8 @@ final class Utils {
      */
     public static String findClassName(ArchivePath path) {
         String className = path.get();
-        className = className.replaceAll("/WEB-INF/classes/", "");
+        className = className.replaceAll("/WEB-INF/classes/", "")
+                .replaceAll("/META-INF/versions/\\d*/", "");
         if (className.charAt(0) == '/') {
             className = className.substring(1);
         }


### PR DESCRIPTION
…ocessing.

@Fromage this should fix the issue you were seeing.
If I am not mistaken then in Java 9+ when you attempt to load a class (`ClassLoader.loadClass()`), then it should automagically prefer the sources in MR jars, so the only issue here is getting correct class name. Please feel free to correct me.
Either way, it does fix the test issues you had in https://github.com/smallrye/smallrye-context-propagation/pull/98

Fixes #61 