### PR TITLE
Adapt container to recognize and honor annotated discovery mode.

### DIFF
--- a/impl/src/main/java/org/jboss/arquillian/container/weld/embedded/WeldMockContainer.java
+++ b/impl/src/main/java/org/jboss/arquillian/container/weld/embedded/WeldMockContainer.java
@@ -106,7 +106,7 @@ public class WeldMockContainer implements DeployableContainer<WeldMockConfigurat
         BeansXml beansXml = BeansXmlUtil.prepareBeansXml(beansXmlParser, findBeansXml(archive), true);
         Environment environment = Environments.valueOf(configuration.get().getEnvironment());
         TestContainer container = new TestContainer(findArchiveId(archive), beansXml,
-                findBeanClasses(archive, classLoader, beansXml, serviceRegistry.get(ResourceLoader.class)), environment, true);
+                findBeanClasses(archive, classLoader, beansXml, serviceRegistry.get(ResourceLoader.class), environment), environment, true);
         Bootstrap bootstrap = container.getBootstrap();
 
         contextClassLoaderManagerProducer.set(classLoaderManager);

--- a/impl/src/test/java/org/jboss/arquillian/container/weld/embedded/UtilsTestCase.java
+++ b/impl/src/test/java/org/jboss/arquillian/container/weld/embedded/UtilsTestCase.java
@@ -19,6 +19,7 @@ package org.jboss.arquillian.container.weld.embedded;
 import java.util.Collection;
 
 import org.jboss.arquillian.container.weld.embedded.beans.MyBean;
+import org.jboss.weld.bootstrap.api.Environments;
 import org.jboss.weld.bootstrap.spi.BeansXml;
 import org.jboss.weld.resources.DefaultResourceLoader;
 import org.junit.Assert;
@@ -50,7 +51,7 @@ public class UtilsTestCase
 
       try
       {
-         Collection<Class<?>> classes = Utils.findBeanClasses(archive, classLoader, BeansXml.EMPTY_BEANS_XML, DefaultResourceLoader.INSTANCE);
+         Collection<Class<?>> classes = Utils.findBeanClasses(archive, classLoader, BeansXml.EMPTY_BEANS_XML, DefaultResourceLoader.INSTANCE, Environments.EE_INJECT);
          Assert.assertEquals(1, classes.size());
       }
       finally
@@ -70,7 +71,7 @@ public class UtilsTestCase
 
       try
       {
-         Collection<Class<?>> classes = Utils.findBeanClasses(archive, classLoader, BeansXml.EMPTY_BEANS_XML, DefaultResourceLoader.INSTANCE);
+         Collection<Class<?>> classes = Utils.findBeanClasses(archive, classLoader, BeansXml.EMPTY_BEANS_XML, DefaultResourceLoader.INSTANCE, Environments.EE_INJECT);
          Assert.assertTrue(classes.isEmpty());
       }
       finally


### PR DESCRIPTION
Fixes #107 

The crux of this change is that CDI 4.0 will change the default perception of empty beans.xml from `all` to `annotated`. This changes what beans should and shouldn't be discovered by default. Up until this point, arq-conteiner-weld was simply using `all` at all times.

I am currently testing this with Weld to see if further changes are needed, hence it is now a draft.