### PR TITLE
Change the scope of EJB dependency to compile as in doesn't need to b…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,8 @@
                 <groupId>jakarta.ejb</groupId>
                 <artifactId>jakarta.ejb-api</artifactId>
                 <version>${ejb.api.version}</version>
-                <scope>provided</scope>
+                <!-- We need this dependency to be "compile" because in some scenarios, it doesn't need to be provided -->
+                <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>jakarta.transaction</groupId>


### PR DESCRIPTION
…e provided in all situations.

Fixes #109 

This wasn't discovered earlier because for Weld testing, we always have the dependency present. However, in some other scenarios, it might be missing and the code now always uses EJB API dependency for access to its annotations.