### PR TITLE
Add support for executing CDI Lite extensions. Upgrade Weld to version 5

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -12,9 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         java:
-          - { name: "8",
-              java-version: 8,
-          }
           - {
             name: "11",
             java-version: 11,

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -59,6 +59,10 @@
             <artifactId>weld-core-impl</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-lite-extension-translator</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>

--- a/impl/src/main/java/org/jboss/arquillian/container/weld/embedded/extension/BuildCompatibleExtensionTranslator.java
+++ b/impl/src/main/java/org/jboss/arquillian/container/weld/embedded/extension/BuildCompatibleExtensionTranslator.java
@@ -1,0 +1,12 @@
+package org.jboss.arquillian.container.weld.embedded.extension;
+
+import org.jboss.weld.lite.extension.translator.LiteExtensionTranslator;
+
+/**
+ * Meant to be same as {@link LiteExtensionTranslator}; this class is present only so that we can register a service
+ * provider that originates from this JAR
+ *
+ * @see org.jboss.weld.lite.extension.translator.LiteExtensionTranslator
+ */
+public class BuildCompatibleExtensionTranslator extends LiteExtensionTranslator {
+}

--- a/impl/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
+++ b/impl/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+org.jboss.arquillian.container.weld.embedded.extension.BuildCompatibleExtensionTranslator

--- a/impl/src/test/java/org/jboss/arquillian/container/weld/embedded/beans/LoopingProducer.java
+++ b/impl/src/test/java/org/jboss/arquillian/container/weld/embedded/beans/LoopingProducer.java
@@ -17,6 +17,7 @@
  */
 package org.jboss.arquillian.container.weld.embedded.beans;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 
 /**
@@ -25,6 +26,7 @@ import jakarta.enterprise.inject.Produces;
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
  * @version $Revision: $
  */
+@Dependent
 public class LoopingProducer
 {
    @Produces 

--- a/impl/src/test/java/org/jboss/arquillian/container/weld/embedded/trace/TracedBeanOne.java
+++ b/impl/src/test/java/org/jboss/arquillian/container/weld/embedded/trace/TracedBeanOne.java
@@ -1,6 +1,9 @@
 package org.jboss.arquillian.container.weld.embedded.trace;
 
+import jakarta.enterprise.context.Dependent;
+
 @Trace
+@Dependent
 public class TracedBeanOne {
 
 	public void call() {

--- a/impl/src/test/java/org/jboss/arquillian/container/weld/embedded/trace/TracedBeanTwo.java
+++ b/impl/src/test/java/org/jboss/arquillian/container/weld/embedded/trace/TracedBeanTwo.java
@@ -1,6 +1,9 @@
 package org.jboss.arquillian.container.weld.embedded.trace;
 
+import jakarta.enterprise.context.Dependent;
+
 @Trace
+@Dependent
 public class TracedBeanTwo {
 
 	public void call() {

--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,11 @@
         <version.arquillian_core>1.7.0.Alpha10</version.arquillian_core>
 
         <!-- TODO Circular dependency on Weld - will need to be updated after release along with CDI API version -->
-        <weld.api.version>4.0.SP1</weld.api.version>
-        <weld.core.version>4.0.2.Final</weld.core.version>
+        <weld.api.version>5.0.Beta2</weld.api.version>
+        <weld.core.version>5.0.0.Alpha1</weld.core.version>
       
         <!-- Versioning -->
-        <cdi.api.version>3.0.0</cdi.api.version>
+        <cdi.api.version>4.0.0.Beta2</cdi.api.version>
         <ejb.api.version>4.0.0</ejb.api.version>
         <jta.api.version>2.0.0</jta.api.version>
         <jpa.api.version>3.0.0</jpa.api.version>
@@ -85,6 +85,13 @@
                 <artifactId>weld-core-impl</artifactId>
                 <version>${weld.core.version}</version>
                 <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.weld</groupId>
+                <artifactId>weld-lite-extension-translator</artifactId>
+                <version>${weld.core.version}</version>
+                <!-- Cannot be provided, we need this dependency so that we can have META-INF entry for the CDI extension -->
+                <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>jakarta.enterprise</groupId>


### PR DESCRIPTION
Fixes #113 


Upgrades Weld API and impl to version 5.
Introduces support for new CDI Lite extensions - since this container bootstraps Weld on its own, it also needs to register newly added portable extension through which we execute build compatible extensions.

We'll again need a release with this to be able to bump it on Weld side and test CDI TCK with this container (after https://github.com/eclipse-ee4j/cdi-tck/pull/312 is merged).