### PR TITLE
Update dependencies to latest version, include CDI EL API

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -13,18 +13,19 @@ jobs:
       matrix:
         java:
           - {
-            name: "11",
-            java-version: 11,
+            name: "17",
+            java-version: 17,
           }
           - {
-            name: "16",
-            java-version: 16,
+            name: "21",
+            java-version: 21,
           }
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.1
       - name: Set up JDK ${{ matrix.java.name }}
-        uses: actions/setup-java@v1.4.3
+        uses: actions/setup-java@v4.0.0
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java.java-version }}
       - name: "Build with Maven"
         run: |

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -67,6 +67,10 @@
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-el-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.el</groupId>
             <artifactId>jakarta.el-api</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -30,18 +30,18 @@
     <properties>
 
         <!-- Versioning -->
-        <version.arquillian_core>1.7.0.Alpha10</version.arquillian_core>
+        <version.arquillian_core>1.8.0.Final</version.arquillian_core>
 
         <!-- TODO Circular dependency on Weld - will need to be updated after release along with CDI API version -->
-        <weld.api.version>5.0.Beta2</weld.api.version>
-        <weld.core.version>5.0.0.Alpha1</weld.core.version>
+        <weld.api.version>6.0.Alpha2</weld.api.version>
+        <weld.core.version>6.0.0.Alpha1</weld.core.version>
       
         <!-- Versioning -->
-        <cdi.api.version>4.0.0.Beta2</cdi.api.version>
-        <ejb.api.version>4.0.0</ejb.api.version>
-        <jta.api.version>2.0.0</jta.api.version>
-        <jpa.api.version>3.0.0</jpa.api.version>
-        <javax.el.version>4.0.0</javax.el.version>
+        <cdi.api.version>4.1.0-M1</cdi.api.version>
+        <ejb.api.version>4.0.1</ejb.api.version>
+        <jta.api.version>2.0.1</jta.api.version>
+        <jpa.api.version>3.2.0-M1</jpa.api.version>
+        <javax.el.version>6.0.0-M1</javax.el.version>
         <shrinkwrap.descriptors.version>2.0.0</shrinkwrap.descriptors.version>
 
         <!-- override from parent -->
@@ -98,6 +98,11 @@
                 <artifactId>jakarta.enterprise.cdi-api</artifactId>
                 <version>${cdi.api.version}</version>
                 <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-el-api</artifactId>
+                <version>${cdi.api.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.el</groupId>


### PR DESCRIPTION
Fixes #117 

Even though I linked this to #117 the main reason for this update is to include the CDI EL API artifact, otherwise testing will fail with latest Weld.

The updates also mean this version will target next EE version so we might want to bump up major version of this project?

I'll also need a release (doesn't need to be Final) in order to bump the version in Weld.
Do you think you could do that @starksm64?